### PR TITLE
Change #background color to #202020 while using en_Night.css

### DIFF
--- a/www/css/es_Night.css
+++ b/www/css/es_Night.css
@@ -15,3 +15,7 @@ body {
 fieldset {
    color:#808080;
 }
+
+#background {
+	background-color: #202020;
+}


### PR DESCRIPTION
During Fullscreen display the image might not cover the entire screen, hence the background is exposed and is #ffffff even if the 'Night' Style is used.  This modification will change the background to #202020 while using the 'Night' Style or en_Night.css.